### PR TITLE
CPP cleanup

### DIFF
--- a/quickcheck-classes.cabal
+++ b/quickcheck-classes.cabal
@@ -92,12 +92,21 @@ library
     , tagged
   if impl(ghc > 7.4) && impl(ghc < 7.6)
     build-depends: ghc-prim
+  if impl(ghc > 8.5)
+    cpp-options: -DHAVE_QUANTIFIED_CONSTRAINTS
+  if (impl(transformers > 0.5.0) || impl(base > 4.9.0)) && impl(QuickCheck > 2.10.0)
+    cpp-options: -DHAVE_HIGHER_KINDED_2
+  if (impl(transformers > 0.4.0) || impl(base > 4.9.0)) && impl(QuickCheck > 2.10.0)
+    cpp-options: -DHAVE_HIGHER_KINDED_1
   if flag(aeson)
     build-depends: aeson >= 1.1
+    cpp-options: -DHAVE_AESON
   if flag(semigroupoids)
     build-depends: semigroupoids 
+    cpp-options: -DHAVE_SEMIGROUPOIDS
   if flag(semirings)
     build-depends: semirings >= 0.2.1.1
+    cpp-options: -DHAVE_SEMIRINGS
   default-language: Haskell2010
 
 test-suite test

--- a/quickcheck-classes.cabal
+++ b/quickcheck-classes.cabal
@@ -102,6 +102,7 @@ library
     , containers >= 0.4.2.1
     , semigroups >= 0.17
     , tagged
+    , fail
   if impl(ghc > 7.4) && impl(ghc < 7.6)
     build-depends: ghc-prim
   if impl(ghc > 8.5)

--- a/quickcheck-classes.cabal
+++ b/quickcheck-classes.cabal
@@ -53,6 +53,8 @@ flag unary-laws
 flag binary-laws
   description:
     Include infrastructure for testing class laws of binary type constructors.
+    Disabling `unary-laws` while keeping `binary-laws` enabled is an unsupported
+    configuration.
   default: True
   manual: False
 

--- a/quickcheck-classes.cabal
+++ b/quickcheck-classes.cabal
@@ -44,6 +44,18 @@ flag semirings
     default: True
     manual: True
 
+flag unary-laws
+  description:
+    Include infrastructure for testing class laws of unary type constructors.
+  default: True
+  manual: False
+
+flag binary-laws
+  description:
+    Include infrastructure for testing class laws of binary type constructors.
+  default: True
+  manual: False
+
 library
   hs-source-dirs: src
   exposed-modules:
@@ -94,10 +106,16 @@ library
     build-depends: ghc-prim
   if impl(ghc > 8.5)
     cpp-options: -DHAVE_QUANTIFIED_CONSTRAINTS
-  if (impl(transformers > 0.5.0) || impl(base > 4.9.0)) && impl(QuickCheck > 2.10.0)
-    cpp-options: -DHAVE_HIGHER_KINDED_2
-  if (impl(transformers > 0.4.0) || impl(base > 4.9.0)) && impl(QuickCheck > 2.10.0)
-    cpp-options: -DHAVE_HIGHER_KINDED_1
+  if flag(unary-laws)
+    build-depends:
+        transformers >= 0.4.0
+      , QuickCheck >= 2.10.0
+    cpp-options: -DHAVE_UNARY_LAWS
+  if flag(binary-laws)
+    build-depends:
+        transformers >= 0.5.0
+      , QuickCheck >= 2.10.0
+    cpp-options: -DHAVE_BINARY_LAWS
   if flag(aeson)
     build-depends: aeson >= 1.1
     cpp-options: -DHAVE_AESON
@@ -123,10 +141,18 @@ test-suite test
     , vector
     , transformers
     , tagged
+  if impl(ghc > 8.5)
+    cpp-options: -DHAVE_QUANTIFIED_CONSTRAINTS
+  if flag(unary-laws)
+    cpp-options: -DHAVE_UNARY_LAWS
+  if flag(binary-laws)
+    cpp-options: -DHAVE_BINARY_LAWS
   if flag(aeson)
     build-depends: aeson
+    cpp-options: -DHAVE_AESON
   if flag(semigroupoids)
     build-depends: semigroupoids
+    cpp-options: -DHAVE_SEMIGROUPOIDS
   default-language: Haskell2010
 
 source-repository head

--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -22,7 +22,7 @@ module Test.QuickCheck.Classes
 #if MIN_VERSION_base(4,7,0)
   , isListLaws
 #endif
-#if defined(VERSION_aeson)
+#if HAVE_AESON
   , jsonLaws
 #endif
   , monoidLaws
@@ -85,7 +85,7 @@ import Test.QuickCheck.Classes.Integral
 #if MIN_VERSION_base(4,7,0)
 import Test.QuickCheck.Classes.IsList
 #endif
-#if defined(VERSION_aeson)
+#if HAVE_AESON
 import Test.QuickCheck.Classes.Json
 #endif
 import Test.QuickCheck.Classes.Monoid

--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -33,7 +33,7 @@ module Test.QuickCheck.Classes
   , primLaws
   , semigroupLaws
   , commutativeSemigroupLaws
-#if defined(VERSION_semirings)
+#if HAVE_SEMIRINGS
   , semiringLaws
 #endif
   , showReadLaws
@@ -92,7 +92,7 @@ import Test.QuickCheck.Classes.Monoid
 import Test.QuickCheck.Classes.Ord
 import Test.QuickCheck.Classes.Prim
 import Test.QuickCheck.Classes.Semigroup
-#if defined(VERSION_semirings)
+#if HAVE_SEMIRINGS
 import Test.QuickCheck.Classes.Semiring
 #endif
 import Test.QuickCheck.Classes.ShowRead

--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -38,19 +38,14 @@ module Test.QuickCheck.Classes
 #endif
   , showReadLaws
   , storableLaws
-#if MIN_VERSION_QuickCheck(2,10,0) && (MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0))
-    -- ** Higher-Kinded Types
+#if HAVE_UNARY_LAWS
+    -- ** Unary type constructors
   , alternativeLaws
 #if defined(VERSION_semigroupoids)
   , altLaws
   , applyLaws
 #endif
   , applicativeLaws
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
-  , bifunctorLaws
-  , categoryLaws
-  , commutativeCategoryLaws
-#endif
   , foldableLaws
   , functorLaws
   , monadLaws
@@ -60,11 +55,17 @@ module Test.QuickCheck.Classes
   , plusLaws
   , extendedPlusLaws
 #endif
-#if defined(VERSION_semigroupoids) && (MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0))
+  , traversableLaws
+#endif
+#if HAVE_BINARY_LAWS
+    -- ** Binary type constructors
+  , bifunctorLaws
+  , categoryLaws
+  , commutativeCategoryLaws
+#if defined(VERSION_semigroupoids)
   , semigroupoidLaws
   , commutativeSemigroupoidLaws
 #endif
-  , traversableLaws
 #endif
     -- * Types
   , Laws(..)
@@ -97,32 +98,31 @@ import Test.QuickCheck.Classes.Semiring
 import Test.QuickCheck.Classes.ShowRead
 import Test.QuickCheck.Classes.Storable
 
--- Higher-Kinded Types
-
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+-- Unary type constructors
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Alternative
 #if defined(VERSION_semigroupoids)
 import Test.QuickCheck.Classes.Alt
 import Test.QuickCheck.Classes.Apply
 #endif
 import Test.QuickCheck.Classes.Applicative
-#if MIN_VERSION_transformers(0,5,0)
-import Test.QuickCheck.Classes.Bifunctor
-#endif
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
-import Test.QuickCheck.Classes.Category
-#endif
 import Test.QuickCheck.Classes.Foldable
 import Test.QuickCheck.Classes.Functor
 import Test.QuickCheck.Classes.Monad
 import Test.QuickCheck.Classes.MonadPlus
 import Test.QuickCheck.Classes.MonadZip
-#if defined(VERSION_semigroupoids) && MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if defined(VERSION_semigroupoids)
 import Test.QuickCheck.Classes.Plus
-import Test.QuickCheck.Classes.Semigroupoid
 #endif
 import Test.QuickCheck.Classes.Traversable
+#endif
+
+-- Binary type constructors
+#if HAVE_BINARY_LAWS
+import Test.QuickCheck.Classes.Bifunctor
+import Test.QuickCheck.Classes.Category
+#if defined(VERSION_semigroupoids)
+import Test.QuickCheck.Classes.Semigroupoid
 #endif
 #endif
 

--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -41,7 +41,7 @@ module Test.QuickCheck.Classes
 #if HAVE_UNARY_LAWS
     -- ** Unary type constructors
   , alternativeLaws
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
   , altLaws
   , applyLaws
 #endif
@@ -51,7 +51,7 @@ module Test.QuickCheck.Classes
   , monadLaws
   , monadPlusLaws
   , monadZipLaws
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
   , plusLaws
   , extendedPlusLaws
 #endif
@@ -62,7 +62,7 @@ module Test.QuickCheck.Classes
   , bifunctorLaws
   , categoryLaws
   , commutativeCategoryLaws
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
   , semigroupoidLaws
   , commutativeSemigroupoidLaws
 #endif
@@ -101,7 +101,7 @@ import Test.QuickCheck.Classes.Storable
 -- Unary type constructors
 #if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Alternative
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
 import Test.QuickCheck.Classes.Alt
 import Test.QuickCheck.Classes.Apply
 #endif
@@ -111,7 +111,7 @@ import Test.QuickCheck.Classes.Functor
 import Test.QuickCheck.Classes.Monad
 import Test.QuickCheck.Classes.MonadPlus
 import Test.QuickCheck.Classes.MonadZip
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
 import Test.QuickCheck.Classes.Plus
 #endif
 import Test.QuickCheck.Classes.Traversable
@@ -121,7 +121,7 @@ import Test.QuickCheck.Classes.Traversable
 #if HAVE_BINARY_LAWS
 import Test.QuickCheck.Classes.Bifunctor
 import Test.QuickCheck.Classes.Category
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
 import Test.QuickCheck.Classes.Semigroupoid
 #endif
 #endif

--- a/src/Test/QuickCheck/Classes/Alt.hs
+++ b/src/Test/QuickCheck/Classes/Alt.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -51,7 +51,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 --   @f '<$>' (a 'Alt.<!>' b) ≡ (f '<$>' a) 'Alt.<!>' (f '<$>' b)@
 #if defined(VERSION_semigroupoids)
 altLaws :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Alt f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Alt f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -63,7 +63,7 @@ altLaws p = Laws "Alt"
   ]
 
 altAssociative :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Alt f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Alt f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -72,7 +72,7 @@ altAssociative :: forall proxy f.
 altAssociative _ = property $ \(Apply (a :: f Integer)) (Apply (b :: f Integer)) (Apply (c :: f Integer)) -> eq1 ((a Alt.<!> b) Alt.<!> c) (a Alt.<!> (b Alt.<!> c))
 
 altLeftDistributive :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Alt f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Alt f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/Alt.hs
+++ b/src/Test/QuickCheck/Classes/Alt.hs
@@ -9,11 +9,9 @@
 
 module Test.QuickCheck.Classes.Alt
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 #if defined(VERSION_semigroupoids)
     altLaws
-#endif
 #endif
 #endif
 ) where
@@ -26,22 +24,18 @@ import qualified Data.Functor.Alt as Alt
 #endif
 
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following alt properties:
 --
@@ -81,5 +75,3 @@ altLeftDistributive :: forall proxy f.
 altLeftDistributive _ = property $ \(Apply (a :: f Integer)) (Apply (b :: f Integer)) -> eq1 (id <$> (a Alt.<!> b)) ((id <$> a) Alt.<!> (id <$> b))
 #endif
 #endif
-#endif
-

--- a/src/Test/QuickCheck/Classes/Alt.hs
+++ b/src/Test/QuickCheck/Classes/Alt.hs
@@ -9,33 +9,22 @@
 
 module Test.QuickCheck.Classes.Alt
   (
-#if HAVE_UNARY_LAWS
-#if defined(VERSION_semigroupoids)
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_UNARY_LAWS)
     altLaws
-#endif
 #endif
 ) where
 
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_UNARY_LAWS)
 import Data.Functor
-
-#if defined(VERSION_semigroupoids)
 import Data.Functor.Alt (Alt)
 import qualified Data.Functor.Alt as Alt
-#endif
-
 import Test.QuickCheck hiding ((.&.))
-#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
-#endif
-
-#if HAVE_UNARY_LAWS
 
 -- | Tests the following alt properties:
 --
@@ -43,7 +32,6 @@ import Test.QuickCheck.Classes.Compat (eq1)
 --   @(a 'Alt.<!>' b) 'Alt.<!>' c ≡ a 'Alt.<!>' (b 'Alt.<!>' c)@
 -- [/Left Distributivity/]
 --   @f '<$>' (a 'Alt.<!>' b) ≡ (f '<$>' a) 'Alt.<!>' (f '<$>' b)@
-#if defined(VERSION_semigroupoids)
 altLaws :: forall proxy f.
 #if HAVE_QUANTIFIED_CONSTRAINTS
   (Alt f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
@@ -73,5 +61,4 @@ altLeftDistributive :: forall proxy f.
 #endif
   => proxy f -> Property
 altLeftDistributive _ = property $ \(Apply (a :: f Integer)) (Apply (b :: f Integer)) -> eq1 (id <$> (a Alt.<!> b)) ((id <$> a) Alt.<!> (id <$> b))
-#endif
 #endif

--- a/src/Test/QuickCheck/Classes/Alternative.hs
+++ b/src/Test/QuickCheck/Classes/Alternative.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -44,7 +44,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 -- [/Associativity/]
 --   @a '<|>' (b '<|>' c) ≡ (a '<|>' b) '<|>' c)@
 alternativeLaws ::
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Alternative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Alternative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -57,7 +57,7 @@ alternativeLaws p = Laws "Alternative"
   ]
 
 alternativeLeftIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Alternative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Alternative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -66,7 +66,7 @@ alternativeLeftIdentity :: forall proxy f.
 alternativeLeftIdentity _ = property $ \(Apply (a :: f Integer)) -> (eq1 (empty <|> a) a)
 
 alternativeRightIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Alternative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Alternative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -75,7 +75,7 @@ alternativeRightIdentity :: forall proxy f.
 alternativeRightIdentity _ = property $ \(Apply (a :: f Integer)) -> (eq1 a (empty <|> a))
 
 alternativeAssociativity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Alternative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Alternative f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/Alternative.hs
+++ b/src/Test/QuickCheck/Classes/Alternative.hs
@@ -9,31 +9,25 @@
 
 module Test.QuickCheck.Classes.Alternative
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     alternativeLaws
-#endif
 #endif
   ) where
 
 import Control.Applicative (Alternative(..))
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following alternative properties:
 --
@@ -84,6 +78,3 @@ alternativeAssociativity :: forall proxy f.
 alternativeAssociativity _ = property $ \(Apply (a :: f Integer)) (Apply (b :: f Integer)) (Apply (c :: f Integer)) -> eq1 (a <|> (b <|> c)) ((a <|> b) <|> c)
 
 #endif
-
-#endif
-

--- a/src/Test/QuickCheck/Classes/Applicative.hs
+++ b/src/Test/QuickCheck/Classes/Applicative.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -48,7 +48,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 -- [/LiftA2 (1)/]
 --   @('<*>') ≡ 'liftA2' 'id'@
 applicativeLaws ::
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Applicative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -64,7 +64,7 @@ applicativeLaws p = Laws "Applicative"
   ]
 
 applicativeIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Applicative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -73,7 +73,7 @@ applicativeIdentity :: forall proxy f.
 applicativeIdentity _ = property $ \(Apply (a :: f Integer)) -> eq1 (pure id <*> a) a
 
 applicativeComposition :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Applicative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -85,7 +85,7 @@ applicativeComposition _ = property $ \(Apply (u' :: f QuadraticEquation)) (Appl
    in eq1 (pure (.) <*> u <*> v <*> w) (u <*> (v <*> w))
 
 applicativeHomomorphism :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a))
 #else
   (Applicative f, Eq1 f, Show1 f)
@@ -96,7 +96,7 @@ applicativeHomomorphism _ = property $ \(e :: QuadraticEquation) (a :: Integer) 
    in eq1 (pure f <*> pure a) (pure (f a) :: f Integer)
 
 applicativeInterchange :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Applicative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -107,7 +107,7 @@ applicativeInterchange _ = property $ \(Apply (u' :: f QuadraticEquation)) (y ::
    in eq1 (u <*> pure y) (pure ($ y) <*> u)
 
 applicativeLiftA2_1 :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Applicative f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/Applicative.hs
+++ b/src/Test/QuickCheck/Classes/Applicative.hs
@@ -9,31 +9,25 @@
 
 module Test.QuickCheck.Classes.Applicative
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     applicativeLaws
-#endif
 #endif
   ) where
 
 import Control.Applicative
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following applicative properties:
 --
@@ -118,6 +112,3 @@ applicativeLiftA2_1 _ = property $ \(Apply (f' :: f QuadraticEquation)) (Apply (
    in eq1 (liftA2 id f x) (f <*> x)
 
 #endif
-
-#endif
-

--- a/src/Test/QuickCheck/Classes/Apply.hs
+++ b/src/Test/QuickCheck/Classes/Apply.hs
@@ -9,11 +9,9 @@
 
 module Test.QuickCheck.Classes.Apply
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 #if defined(VERSION_semigroupoids)
     applyLaws
-#endif
 #endif
 #endif
 ) where
@@ -25,22 +23,18 @@ import qualified Data.Functor.Apply as FunctorApply
 #endif
 
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following alt properties:
 --
@@ -70,5 +64,3 @@ applyLiftF2_1 _ = property $ \(Apply (f' :: f QuadraticEquation)) (Apply (x :: f
   in eq1 (FunctorApply.liftF2 id f x) (f FunctorApply.<.> x)
 #endif
 #endif
-#endif
-

--- a/src/Test/QuickCheck/Classes/Apply.hs
+++ b/src/Test/QuickCheck/Classes/Apply.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -48,7 +48,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 --   @('FunctorApply.<.>') ≡ 'liftF2' 'id'@
 #if defined(VERSION_semigroupoids)
 applyLaws ::
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (FunctorApply.Apply f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (FunctorApply.Apply f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -59,7 +59,7 @@ applyLaws p = Laws "Apply"
   ]
 
 applyLiftF2_1 :: forall proxy f. 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (FunctorApply.Apply f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (FunctorApply.Apply f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/Apply.hs
+++ b/src/Test/QuickCheck/Classes/Apply.hs
@@ -9,38 +9,26 @@
 
 module Test.QuickCheck.Classes.Apply
   (
-#if HAVE_UNARY_LAWS
-#if defined(VERSION_semigroupoids)
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_UNARY_LAWS)
     applyLaws
-#endif
 #endif
 ) where
 
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_UNARY_LAWS)
 import Data.Functor
-
-#if defined(VERSION_semigroupoids)
 import qualified Data.Functor.Apply as FunctorApply
-#endif
-
 import Test.QuickCheck hiding ((.&.))
-#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
-#endif
-
-#if HAVE_UNARY_LAWS
 
 -- | Tests the following alt properties:
 --
 -- [/LiftF2 (1)/]
 --   @('FunctorApply.<.>') ≡ 'liftF2' 'id'@
-#if defined(VERSION_semigroupoids)
 applyLaws ::
 #if HAVE_QUANTIFIED_CONSTRAINTS
   (FunctorApply.Apply f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
@@ -62,5 +50,4 @@ applyLiftF2_1 :: forall proxy f.
 applyLiftF2_1 _ = property $ \(Apply (f' :: f QuadraticEquation)) (Apply (x :: f Integer)) ->
   let f = fmap runQuadraticEquation f'
   in eq1 (FunctorApply.liftF2 id f x) (f FunctorApply.<.> x)
-#endif
 #endif

--- a/src/Test/QuickCheck/Classes/Arrow.hs
+++ b/src/Test/QuickCheck/Classes/Arrow.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -10,9 +10,9 @@
 -- N.B.: This module is not currently built.
 module Test.QuickCheck.Classes.Arrow
   (
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
     arrowLaws
-#endif  
+#endif
   ) where
 
 import Prelude hiding (id, (.))
@@ -20,19 +20,17 @@ import Control.Applicative
 import Control.Arrow (Arrow(..))
 import Control.Category (Category(..), (>>>), (<<<))
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_BINARY_LAWS
 import Data.Functor.Classes (Eq2,Show2)
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_BINARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq2)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 
 -- | Tests the following 'Arrow' properties:
 -- [/Law1/]
@@ -56,7 +54,7 @@ import Test.QuickCheck.Classes.Compat (eq2)
 -- /Note/: This property test is only available when this package is built with
 -- @base-4.9+@ or @transformers-0.5+@.
 arrowLaws :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Arrow f, forall a b. (Eq a, Eq b) => Eq (f a b), forall a b. (Show a, Show b) => Show (f a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b))
 #else
   (Arrow f, Eq2 f, Show2 f, Arbitrary2 f)
@@ -67,15 +65,13 @@ arrowLaws p = Laws "Arrow"
   ]
 
 arrowLaw1 :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Arrow f, forall a b. (Eq a, Eq b) => Eq (f a b), forall a b. (Show a, Show b) => Show (f a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b))
 #else
   (Arrow f, Eq2 f, Show2 f, Arbitrary2 f)
 #endif
   => proxy f -> Property
 arrowLaw1 _ = property $ \(Apply2 (x :: f Integer Integer)) -> eq2 (arr id x) (id x)
-
-#endif
 
 #endif
 

--- a/src/Test/QuickCheck/Classes/Bifunctor.hs
+++ b/src/Test/QuickCheck/Classes/Bifunctor.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -46,7 +46,7 @@ import Test.QuickCheck.Classes.Compat (eq2)
 -- /Note/: This property test is only available when this package is built with
 -- @base-4.9+@ or @transformers-0.5+@.
 bifunctorLaws :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Bifunctor f, forall a b. (Eq a, Eq b) => Eq (f a b), forall a b. (Show a, Show b) => Show (f a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b))
 #else
   (Bifunctor f, Eq2 f, Show2 f, Arbitrary2 f)
@@ -60,7 +60,7 @@ bifunctorLaws p = Laws "Bifunctor"
   ]
 
 bifunctorIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Bifunctor f, forall a b. (Eq a, Eq b) => Eq (f a b), forall a b. (Show a, Show b) => Show (f a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b))
 #else
   (Bifunctor f, Eq2 f, Show2 f, Arbitrary2 f)
@@ -69,7 +69,7 @@ bifunctorIdentity :: forall proxy f.
 bifunctorIdentity _ = property $ \(Apply2 (x :: f Integer Integer)) -> eq2 (bimap id id x) x
 
 bifunctorFirstIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Bifunctor f, forall a b. (Eq a, Eq b) => Eq (f a b), forall a b. (Show a, Show b) => Show (f a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b))
 #else
   (Bifunctor f, Eq2 f, Show2 f, Arbitrary2 f)
@@ -78,7 +78,7 @@ bifunctorFirstIdentity :: forall proxy f.
 bifunctorFirstIdentity _ = property $ \(Apply2 (x :: f Integer Integer)) -> eq2 (first id x) x
 
 bifunctorSecondIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Bifunctor f, forall a b. (Eq a, Eq b) => Eq (f a b), forall a b. (Show a, Show b) => Show (f a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b))
 #else
   (Bifunctor f, Eq2 f, Show2 f, Arbitrary2 f)
@@ -87,7 +87,7 @@ bifunctorSecondIdentity :: forall proxy f.
 bifunctorSecondIdentity _ = property $ \(Apply2 (x :: f Integer Integer)) -> eq2 (second id x) x
 
 bifunctorComposition :: forall proxy f. 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Bifunctor f, forall a b. (Eq a, Eq b) => Eq (f a b), forall a b. (Show a, Show b) => Show (f a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b))
 #else
   (Bifunctor f, Eq2 f, Show2 f, Arbitrary2 f)

--- a/src/Test/QuickCheck/Classes/Bifunctor.hs
+++ b/src/Test/QuickCheck/Classes/Bifunctor.hs
@@ -9,28 +9,24 @@
 
 module Test.QuickCheck.Classes.Bifunctor
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
     bifunctorLaws
-#endif
 #endif
   ) where
 
 import Data.Bifunctor(Bifunctor(..))
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 import Data.Functor.Classes (Eq2,Show2)
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq2)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 
 -- | Tests the following 'Bifunctor' properties:
 --
@@ -94,7 +90,5 @@ bifunctorComposition :: forall proxy f.
 #endif
   => proxy f -> Property
 bifunctorComposition _ = property $ \(Apply2 (z :: f Integer Integer)) -> eq2 (bimap id id z) ((first id . second id) z)
-#endif
 
 #endif
-

--- a/src/Test/QuickCheck/Classes/Category.hs
+++ b/src/Test/QuickCheck/Classes/Category.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -46,7 +46,7 @@ import Test.QuickCheck.Classes.Compat (eq2)
 -- /Note/: This property test is only available when this package is built with
 -- @base-4.9+@ or @transformers-0.5+@.
 categoryLaws :: forall proxy c.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Category c, forall a b. (Eq a, Eq b) => Eq (c a b), forall a b. (Show a, Show b) => Show (c a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (c a b))
 #else
   (Category c, Eq2 c, Show2 c, Arbitrary2 c)
@@ -66,7 +66,7 @@ categoryLaws p = Laws "Category"
 -- /Note/: This property test is only available when this package is built with
 -- @base-4.9+@ or @transformers-0.5+@.
 commutativeCategoryLaws :: forall proxy c.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Category c, forall a b. (Eq a, Eq b) => Eq (c a b), forall a b. (Show a, Show b) => Show (c a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (c a b))
 #else
   (Category c, Eq2 c, Show2 c, Arbitrary2 c)
@@ -77,7 +77,7 @@ commutativeCategoryLaws p = Laws "Commutative Category" $ lawsProperties (catego
   ]
 
 categoryRightIdentity :: forall proxy c.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Category c, forall a b. (Eq a, Eq b) => Eq (c a b), forall a b. (Show a, Show b) => Show (c a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (c a b))
 #else
   (Category c, Eq2 c, Show2 c, Arbitrary2 c)
@@ -86,7 +86,7 @@ categoryRightIdentity :: forall proxy c.
 categoryRightIdentity _ = property $ \(Apply2 (x :: c Integer Integer)) -> eq2 (x . id) x
 
 categoryLeftIdentity :: forall proxy c.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Category c, forall a b. (Eq a, Eq b) => Eq (c a b), forall a b. (Show a, Show b) => Show (c a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (c a b))
 #else
   (Category c, Eq2 c, Show2 c, Arbitrary2 c)
@@ -95,7 +95,7 @@ categoryLeftIdentity :: forall proxy c.
 categoryLeftIdentity _ = property $ \(Apply2 (x :: c Integer Integer)) -> eq2 (id . x) x
 
 categoryAssociativity :: forall proxy c.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Category c, forall a b. (Eq a, Eq b) => Eq (c a b), forall a b. (Show a, Show b) => Show (c a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (c a b))
 #else
   (Category c, Eq2 c, Show2 c, Arbitrary2 c)
@@ -104,7 +104,7 @@ categoryAssociativity :: forall proxy c.
 categoryAssociativity _ = property $ \(Apply2 (f :: c Integer Integer)) (Apply2 (g :: c Integer Integer)) (Apply2 (h :: c Integer Integer)) -> eq2 (f . (g . h)) ((f . g) . h)
 
 categoryCommutativity :: forall proxy c.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Category c, forall a b. (Eq a, Eq b) => Eq (c a b), forall a b. (Show a, Show b) => Show (c a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (c a b))
 #else
   (Category c, Eq2 c, Show2 c, Arbitrary2 c)

--- a/src/Test/QuickCheck/Classes/Category.hs
+++ b/src/Test/QuickCheck/Classes/Category.hs
@@ -9,30 +9,26 @@
 
 module Test.QuickCheck.Classes.Category
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
     categoryLaws
   , commutativeCategoryLaws
-#endif
 #endif
   ) where
 
 import Prelude hiding (id, (.))
 import Control.Category (Category(..))
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 import Data.Functor.Classes (Eq2,Show2)
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq2)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 
 -- | Tests the following 'Category' properties:
 --
@@ -113,6 +109,3 @@ categoryCommutativity :: forall proxy c.
 categoryCommutativity _ = property $ \(Apply2 (f :: c Integer Integer)) (Apply2 (g :: c Integer Integer)) -> eq2 (f . g) (g . f)
 
 #endif
-
-#endif
-

--- a/src/Test/QuickCheck/Classes/Common.hs
+++ b/src/Test/QuickCheck/Classes/Common.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -111,7 +111,7 @@ myForAllShrink displayRhs isValid showInputs name1 calc1 name2 calc2 =
 
 #if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 -- the Functor constraint is needed for transformers-0.4
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 nestedEq1 :: (forall x. Eq x => Eq (f x), forall x. Eq x => Eq (g x), Eq a) => f (g a) -> f (g a) -> Bool
 nestedEq1 = (==)
 #else
@@ -119,7 +119,7 @@ nestedEq1 :: (Eq1 f, Eq1 g, Eq a, Functor f) => f (g a) -> f (g a) -> Bool
 nestedEq1 x y = eq1 (Compose x) (Compose y)
 #endif
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 propNestedEq1 :: (forall x. Eq x => Eq (f x), forall x. Eq x => Eq (g x), Eq a, forall x. Show x => Show (f x), forall x. Show x => Show (g x), Show a)
   => f (g a) -> f (g a) -> Property
 propNestedEq1 = (===)
@@ -289,7 +289,7 @@ instance (Applicative f, Monoid a) => Monoid (Apply f a) where
   mempty = Apply $ pure mempty
   mappend = (SG.<>)
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 deriving instance (forall x. Eq x => Eq (f x), Eq a) => Eq (Apply f a)
 deriving instance (forall x. Arbitrary x => Arbitrary (f x), Arbitrary a) => Arbitrary (Apply f a)
 deriving instance (forall x. Show x => Show (f x), Show a) => Show (Apply f a)
@@ -317,7 +317,7 @@ foldMapA f = getApply . foldMap (Apply . f)
 #if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
 newtype Apply2 f a b = Apply2 { getApply2 :: f a b }
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 deriving instance (forall x y. (Eq x, Eq y) => Eq (f x y), Eq a, Eq b) => Eq (Apply2 f a b)
 deriving instance (forall x y. (Arbitrary x, Arbitrary y) => Arbitrary (f x y), Arbitrary a, Arbitrary b) => Arbitrary (Apply2 f a b)
 deriving instance (forall x y. (Show x, Show y) => Show (f x y), Show a, Show b) => Show (Apply2 f a b)
@@ -365,7 +365,7 @@ runLinearEquationM (LinearEquationM e1 e2) i = if odd i
   then liftM (flip runLinearEquation i) e1
   else liftM (flip runLinearEquation i) e2
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 deriving instance (forall x. Eq x => Eq (m x)) => Eq (LinearEquationM m)
 instance (forall a. Show a => Show (m a)) => Show (LinearEquationM m) where
   show (LinearEquationM a b) = (\f -> f "")

--- a/src/Test/QuickCheck/Classes/Compat.hs
+++ b/src/Test/QuickCheck/Classes/Compat.hs
@@ -7,10 +7,10 @@
 
 module Test.QuickCheck.Classes.Compat
   ( isTrue#
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
   , eq1
 #endif
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
   , eq2
 #endif
   ) where
@@ -19,7 +19,7 @@ module Test.QuickCheck.Classes.Compat
 import GHC.Exts (isTrue#)
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if defined(HAVE_UNARY_LAWS) || defined(HAVE_BINARY_LAWS)
 import qualified Data.Functor.Classes as C
 #endif
 
@@ -28,7 +28,7 @@ isTrue# :: Bool -> Bool
 isTrue# b = b
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 #if HAVE_QUANTIFIED_CONSTRAINTS
 eq1 :: (forall a. Eq a => Eq (f a), Eq a) => f a -> f a -> Bool
 eq1 = (==)
@@ -38,7 +38,7 @@ eq1 = C.eq1
 #endif
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 #if HAVE_QUANTIFIED_CONSTRAINTS
 eq2 :: (forall a. (Eq a, Eq b) => Eq (f a b), Eq a, Eq b) => f a b -> f a b -> Bool
 eq2 = (==)

--- a/src/Test/QuickCheck/Classes/Compat.hs
+++ b/src/Test/QuickCheck/Classes/Compat.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -29,7 +29,7 @@ isTrue# b = b
 #endif
 
 #if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 eq1 :: (forall a. Eq a => Eq (f a), Eq a) => f a -> f a -> Bool
 eq1 = (==)
 #else
@@ -39,7 +39,7 @@ eq1 = C.eq1
 #endif
 
 #if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 eq2 :: (forall a. (Eq a, Eq b) => Eq (f a b), Eq a, Eq b) => f a b -> f a b -> Bool
 eq2 = (==)
 #else

--- a/src/Test/QuickCheck/Classes/Foldable.hs
+++ b/src/Test/QuickCheck/Classes/Foldable.hs
@@ -9,24 +9,22 @@
 
 module Test.QuickCheck.Classes.Foldable
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     foldableLaws
-#endif
 #endif
   ) where
 
 import Data.Monoid
 import Data.Foldable
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
 import Control.Exception (ErrorCall,try,evaluate)
 import Control.Monad.Trans.Class (lift)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-import Test.QuickCheck.Monadic (monadicIO)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
-import Data.Functor.Classes (Eq1,Show1)
 #endif
+import Test.QuickCheck.Monadic (monadicIO)
+#if HAVE_UNARY_LAWS
+import Data.Functor.Classes (Eq1,Show1)
 #endif
 import Test.QuickCheck.Property (Property)
 
@@ -34,13 +32,11 @@ import qualified Data.Foldable as F
 import qualified Data.Semigroup as SG
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following 'Foldable' properties:
 --
@@ -188,6 +184,3 @@ foldableFoldr' _ = property $ \(_ :: ChooseFirst) (_ :: LastNothing) (Apply (xs 
     return (r1 == r2)
 
 #endif
-
-#endif
-

--- a/src/Test/QuickCheck/Classes/Foldable.hs
+++ b/src/Test/QuickCheck/Classes/Foldable.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -70,7 +70,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 -- Note that this checks to ensure that @foldl\'@ and @foldr\'@
 -- are suitably strict.
 foldableLaws :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Foldable f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Foldable f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -79,7 +79,7 @@ foldableLaws :: forall proxy f.
 foldableLaws = foldableLawsInternal
 
 foldableLawsInternal :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Foldable f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Foldable f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -130,7 +130,7 @@ compatToList :: Foldable f => f a -> [a]
 compatToList = foldMap (\x -> [x])
 
 foldableFoldl' :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Foldable f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Foldable f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -159,7 +159,7 @@ foldableFoldl' _ = property $ \(_ :: ChooseSecond) (_ :: LastNothing) (Apply (xs
     return (r1 == r2)
 
 foldableFoldr' :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Foldable f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Foldable f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/Functor.hs
+++ b/src/Test/QuickCheck/Classes/Functor.hs
@@ -11,31 +11,25 @@
 
 module Test.QuickCheck.Classes.Functor
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     functorLaws
-#endif
 #endif
   ) where
 
 import Data.Functor
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following functor properties:
 --
@@ -87,8 +81,6 @@ functorConst :: forall proxy f.
   => proxy f -> Property
 functorConst _ = property $ \(Apply (a :: f Integer)) ->
   eq1 (fmap (const 'X') a) ('X' <$ a)
-
-#endif
 
 #endif
 

--- a/src/Test/QuickCheck/Classes/Functor.hs
+++ b/src/Test/QuickCheck/Classes/Functor.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -46,7 +46,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 -- [/Const/]
 --   @('<$') ≡ 'fmap' 'const'@
 functorLaws ::
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Functor f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Functor f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -60,7 +60,7 @@ functorLaws p = Laws "Functor"
   ]
 
 functorIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Functor f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Functor f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -69,7 +69,7 @@ functorIdentity :: forall proxy f.
 functorIdentity _ = property $ \(Apply (a :: f Integer)) -> eq1 (fmap id a) a
 
 functorComposition :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Functor f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Functor f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -79,7 +79,7 @@ functorComposition _ = property $ \(Apply (a :: f Integer)) ->
   eq1 (fmap func2 (fmap func1 a)) (fmap (func2 . func1) a)
 
 functorConst :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Functor f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Functor f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/Generic.hs
+++ b/src/Test/QuickCheck/Classes/Generic.hs
@@ -11,9 +11,9 @@ module Test.QuickCheck.Classes.Generic
   (
 #if MIN_VERSION_base(4,5,0)
     genericLaws
-#endif
-#if MIN_VERSION_base(4,9,0) && MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
   , generic1Laws
+#endif
 #endif
   ) where
 
@@ -22,7 +22,7 @@ import Control.Applicative
 import Data.Semigroup as SG
 import Data.Monoid as MD
 import GHC.Generics
-#if MIN_VERSION_base(4,9,0)
+#if HAVE_UNARY_LAWS
 import Data.Functor.Classes
 #endif
 import Data.Proxy (Proxy(Proxy))
@@ -62,7 +62,7 @@ fromToInverse ::
   -> Property
 fromToInverse _ _ = property $ \(r :: Rep a x) -> r == (from (to r :: a)) 
 
-#if MIN_VERSION_base(4,9,0) && MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 -- | Tests the following properties:
 --
 -- [/From-To Inverse/]
@@ -73,7 +73,7 @@ fromToInverse _ _ = property $ \(r :: Rep a x) -> r == (from (to r :: a))
 -- /Note:/ This property test is only available when
 -- using @base-4.9@ or newer.
 generic1Laws :: (Generic1 f, Eq1 f, Arbitrary1 f, Show1 f, Eq1 (Rep1 f), Show1 (Rep1 f), Arbitrary1 (Rep1 f))
-  => Proxy f -> Laws
+  => proxy f -> Laws
 generic1Laws p = Laws "Generic1"
   [ ("From1-To1 inverse", fromToInverse1 p)
   , ("To1-From1 inverse", toFromInverse1 p)

--- a/src/Test/QuickCheck/Classes/Generic.hs
+++ b/src/Test/QuickCheck/Classes/Generic.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 {-# OPTIONS_GHC -Wall #-}

--- a/src/Test/QuickCheck/Classes/Json.hs
+++ b/src/Test/QuickCheck/Classes/Json.hs
@@ -5,7 +5,7 @@
 
 module Test.QuickCheck.Classes.Json
   (
-#if defined(VERSION_aeson)
+#if HAVE_AESON
     jsonLaws
 #endif  
   ) where
@@ -14,7 +14,7 @@ import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Property (Property)
 
-#if defined(VERSION_aeson)
+#if HAVE_AESON
 import Data.Aeson (FromJSON(..), ToJSON(..))
 import qualified Data.Aeson as AE
 #endif
@@ -30,7 +30,7 @@ import Test.QuickCheck.Classes.Common (Laws(..))
 --
 -- Note that in the second property, the type of decode is @ByteString -> Value@,
 -- not @ByteString -> a@
-#if defined(VERSION_aeson)
+#if HAVE_AESON
 jsonLaws :: (ToJSON a, FromJSON a, Show a, Arbitrary a, Eq a) => Proxy a -> Laws
 jsonLaws p = Laws "ToJSON/FromJSON"
   [ ("Partial Isomorphism", jsonEncodingPartialIsomorphism p)

--- a/src/Test/QuickCheck/Classes/Monad.hs
+++ b/src/Test/QuickCheck/Classes/Monad.hs
@@ -9,32 +9,26 @@
 
 module Test.QuickCheck.Classes.Monad
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     monadLaws
-#endif
 #endif
   ) where
 
 import Control.Applicative
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
 import Control.Monad (ap)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following monadic properties:
 --
@@ -118,6 +112,3 @@ monadAp _ = property $ \(Apply (f' :: f QuadraticEquation)) (Apply (x :: f Integ
    in eq1 (ap f x) (f <*> x)
 
 #endif
-
-#endif
-

--- a/src/Test/QuickCheck/Classes/Monad.hs
+++ b/src/Test/QuickCheck/Classes/Monad.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -49,7 +49,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 -- [/Ap/]
 --   @('<*>') ≡ 'ap'@
 monadLaws ::
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Monad f, Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Monad f, Applicative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -64,7 +64,7 @@ monadLaws p = Laws "Monad"
   ]
 
 monadLeftIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Monad f, Functor f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Monad f, Functor f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -75,7 +75,7 @@ monadLeftIdentity _ = property $ \(k' :: LinearEquationM f) (a :: Integer) ->
    in eq1 (return a >>= k) (k a)
 
 monadRightIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Monad f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Monad f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -85,7 +85,7 @@ monadRightIdentity _ = property $ \(Apply (m :: f Integer)) ->
   eq1 (m >>= return) m
 
 monadAssociativity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Monad f, Functor f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Monad f, Functor f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -97,7 +97,7 @@ monadAssociativity _ = property $ \(Apply (m :: f Integer)) (k' :: LinearEquatio
    in eq1 (m >>= (\x -> k x >>= h)) ((m >>= k) >>= h)
 
 monadReturn :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Monad f, Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Monad f, Applicative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -107,7 +107,7 @@ monadReturn _ = property $ \(x :: Integer) ->
   eq1 (return x) (pure x :: f Integer)
 
 monadAp :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Monad f, Applicative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Monad f, Applicative f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/MonadFail.hs
+++ b/src/Test/QuickCheck/Classes/MonadFail.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -43,7 +43,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 -- [/Left Zero/]
 -- @'fail' s '>>=' f ≡ 'fail' s@
 monadFailLaws :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadFail f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadFail f, Applicative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -54,7 +54,7 @@ monadFailLaws p = Laws "Monad"
   ]
  
 monadFailLeftZero :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadFail f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadFail f, Functor f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/MonadFail.hs
+++ b/src/Test/QuickCheck/Classes/MonadFail.hs
@@ -9,34 +9,24 @@
 
 module Test.QuickCheck.Classes.MonadFail
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) && MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     monadFailLaws
-#endif
 #endif
   ) where
 
+#if HAVE_UNARY_LAWS
+
 import Control.Applicative
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
 import Control.Monad (ap)
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) && MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
-#endif
-#endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
-#endif
-
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) && MIN_VERSION_transformers(0,4,0)
 
 -- | Tests the following 'MonadFail' properties:
 -- 
@@ -65,6 +55,3 @@ monadFailLeftZero _ = property $ \(k' :: LinearEquationM f) (s :: String) ->
   in eq1 (fail s >>= k) (fail s)
 
 #endif
-
-#endif
-

--- a/src/Test/QuickCheck/Classes/MonadFail.hs
+++ b/src/Test/QuickCheck/Classes/MonadFail.hs
@@ -30,7 +30,7 @@ import Control.Monad.Fail (MonadFail(..))
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 

--- a/src/Test/QuickCheck/Classes/MonadPlus.hs
+++ b/src/Test/QuickCheck/Classes/MonadPlus.hs
@@ -9,31 +9,26 @@
 
 module Test.QuickCheck.Classes.MonadPlus
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     monadPlusLaws
-#endif
 #endif
   ) where
 
 import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Property (Property)
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
-
-#if MIN_VERSION_QuickCheck(2,10,0)
 import Control.Applicative(Alternative(empty))
 import Control.Monad (MonadPlus(mzero,mplus))
+
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
 #endif
-#endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following monad plus properties:
 --
@@ -108,5 +103,3 @@ monadPlusRightZero :: forall proxy f.
 monadPlusRightZero _ = property $ \(Apply (a :: f Integer)) -> eq1 (a >> (mzero :: f Integer)) mzero
 
 #endif
-#endif
-

--- a/src/Test/QuickCheck/Classes/MonadPlus.hs
+++ b/src/Test/QuickCheck/Classes/MonadPlus.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -48,7 +48,7 @@ import Data.Functor.Classes (Eq1,Show1)
 -- [/Right Zero/]
 --   @m '>>' 'mzero' ≡ 'mzero'@
 monadPlusLaws ::
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadPlus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadPlus f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -63,7 +63,7 @@ monadPlusLaws p = Laws "MonadPlus"
   ]
 
 monadPlusLeftIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadPlus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadPlus f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -72,7 +72,7 @@ monadPlusLeftIdentity :: forall proxy f.
 monadPlusLeftIdentity _ = property $ \(Apply (a :: f Integer)) -> eq1 (mplus mzero a) a
 
 monadPlusRightIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadPlus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadPlus f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -81,7 +81,7 @@ monadPlusRightIdentity :: forall proxy f.
 monadPlusRightIdentity _ = property $ \(Apply (a :: f Integer)) -> eq1 (mplus a mzero) a
 
 monadPlusAssociativity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadPlus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadPlus f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -90,7 +90,7 @@ monadPlusAssociativity :: forall proxy f.
 monadPlusAssociativity _ = property $ \(Apply (a :: f Integer)) (Apply (b :: f Integer)) (Apply (c :: f Integer)) -> eq1 (mplus a (mplus b c)) (mplus (mplus a b) c)
 
 monadPlusLeftZero :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadPlus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadPlus f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -99,7 +99,7 @@ monadPlusLeftZero :: forall proxy f.
 monadPlusLeftZero _ = property $ \(k' :: LinearEquationM f) -> eq1 (mzero >>= runLinearEquationM k') mzero
 
 monadPlusRightZero :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadPlus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadPlus f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/MonadZip.hs
+++ b/src/Test/QuickCheck/Classes/MonadZip.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -46,7 +46,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 -- In the laws above, the infix function @'***'@ refers to a typeclass
 -- method of 'Arrow'.
 monadZipLaws ::
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadZip f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadZip f, Applicative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -57,7 +57,7 @@ monadZipLaws p = Laws "MonadZip"
   ]
 
 monadZipNaturality :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadZip f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (MonadZip f, Functor f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/MonadZip.hs
+++ b/src/Test/QuickCheck/Classes/MonadZip.hs
@@ -9,10 +9,8 @@
 
 module Test.QuickCheck.Classes.MonadZip
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     monadZipLaws
-#endif
 #endif
   ) where
 
@@ -20,23 +18,19 @@ import Control.Applicative
 import Control.Arrow (Arrow(..))
 import Control.Monad.Zip (MonadZip(mzip))
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
 import Control.Monad (liftM)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
-#endif
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following monadic zipping properties:
 --
@@ -69,6 +63,3 @@ monadZipNaturality _ = property $ \(f' :: LinearEquation) (g' :: LinearEquation)
    in eq1 (liftM (f *** g) (mzip ma mb)) (mzip (liftM f ma) (liftM g mb))
 
 #endif
-
-#endif
-

--- a/src/Test/QuickCheck/Classes/Plus.hs
+++ b/src/Test/QuickCheck/Classes/Plus.hs
@@ -9,37 +9,27 @@
 
 module Test.QuickCheck.Classes.Plus
   (
-#if HAVE_UNARY_LAWS
-#if defined(VERSION_semigroupoids)
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_UNARY_LAWS)
     plusLaws
   , extendedPlusLaws
 #endif
-#endif
   ) where
 
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_UNARY_LAWS)
 import Data.Functor
-
-#if defined(VERSION_semigroupoids)
 import Data.Functor.Alt (Alt)
 import Data.Functor.Plus (Plus)
 import qualified Data.Functor.Alt as Alt
 import qualified Data.Functor.Plus as Plus
-#endif
 
 import Test.QuickCheck hiding ((.&.))
-#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 import qualified Control.Applicative as Alternative
-#endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
-#endif
-
-#if HAVE_UNARY_LAWS
 
 -- | Tests the following alt properties:
 --
@@ -47,7 +37,6 @@ import Test.QuickCheck.Classes.Compat (eq1)
 --   @'Plus.zero' 'Alt.<!>' m ≡ m@
 -- [/Right Identity/]
 --   @m 'Alt.<!>' 'Plus.zero' ≡ m@
-#if defined(VERSION_semigroupoids)
 plusLaws :: forall proxy f.
 #if HAVE_QUANTIFIED_CONSTRAINTS
   (Plus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
@@ -102,5 +91,4 @@ plusRightIdentity :: forall proxy f.
   => proxy f -> Property
 plusRightIdentity _ = property $ \(Apply (m :: f Integer)) -> eq1 (m Alt.<!> Plus.zero) m
 
-#endif
 #endif

--- a/src/Test/QuickCheck/Classes/Plus.hs
+++ b/src/Test/QuickCheck/Classes/Plus.hs
@@ -9,12 +9,10 @@
 
 module Test.QuickCheck.Classes.Plus
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 #if defined(VERSION_semigroupoids)
     plusLaws
   , extendedPlusLaws
-#endif
 #endif
 #endif
   ) where
@@ -29,23 +27,19 @@ import qualified Data.Functor.Plus as Plus
 #endif
 
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
 import qualified Control.Applicative as Alternative
-#endif
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following alt properties:
 --
@@ -110,5 +104,3 @@ plusRightIdentity _ = property $ \(Apply (m :: f Integer)) -> eq1 (m Alt.<!> Plu
 
 #endif
 #endif
-#endif
-

--- a/src/Test/QuickCheck/Classes/Plus.hs
+++ b/src/Test/QuickCheck/Classes/Plus.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -55,7 +55,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 --   @m 'Alt.<!>' 'Plus.zero' ≡ m@
 #if defined(VERSION_semigroupoids)
 plusLaws :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Plus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Plus f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -71,7 +71,7 @@ plusLaws p = Laws "Plus"
 -- [/Congruency/]
 --   @'Plus.zero' ≡ 'Alternative.empty'@
 extendedPlusLaws :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Plus f, Alternative.Alternative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Plus f, Alternative.Alternative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -82,7 +82,7 @@ extendedPlusLaws p = Laws "Plus extended to Alternative" $ lawsProperties (plusL
   ]
 
 extendedPlusLaw :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Plus f, Alternative.Alternative f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Plus f, Alternative.Alternative f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -91,7 +91,7 @@ extendedPlusLaw :: forall proxy f.
 extendedPlusLaw _ = property $ eq1 (Plus.zero :: f Integer) (Alternative.empty :: f Integer)
 
 plusLeftIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Plus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Plus f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -100,7 +100,7 @@ plusLeftIdentity :: forall proxy f.
 plusLeftIdentity _ = property $ \(Apply (m :: f Integer)) -> eq1 (Plus.zero Alt.<!> m) m
 
 plusRightIdentity :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Plus f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Plus f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/Semigroupoid.hs
+++ b/src/Test/QuickCheck/Classes/Semigroupoid.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -47,7 +47,7 @@ import Test.QuickCheck.Classes.Compat (eq2)
 -- /Note/: This property test is only available when this package is built with
 -- @base-4.9+@ or @transformers-0.5+@.
 semigroupoidLaws :: forall proxy s.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Semigroupoid s, forall a b. (Eq a, Eq b) => Eq (s a b), forall a b. (Show a, Show b) => Show (s a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (s a b))
 #else
   (Semigroupoid s, Eq2 s, Show2 s, Arbitrary2 s)
@@ -65,7 +65,7 @@ semigroupoidLaws p = Laws "Semigroupoid"
 -- /Note/: This property test is only available when this package is built with
 -- @base-4.9+@ or @transformers-0.5+@.
 commutativeSemigroupoidLaws :: forall proxy s.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Semigroupoid s, forall a b. (Eq a, Eq b) => Eq (s a b), forall a b. (Show a, Show b) => Show (s a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (s a b))
 #else
   (Semigroupoid s, Eq2 s, Show2 s, Arbitrary2 s)
@@ -76,7 +76,7 @@ commutativeSemigroupoidLaws p = Laws "Commutative Semigroupoid" $ lawsProperties
   ]
 
 semigroupoidAssociativity :: forall proxy s.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Semigroupoid s, forall a b. (Eq a, Eq b) => Eq (s a b), forall a b. (Show a, Show b) => Show (s a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (s a b))
 #else
   (Semigroupoid s, Eq2 s, Show2 s, Arbitrary2 s)
@@ -85,7 +85,7 @@ semigroupoidAssociativity :: forall proxy s.
 semigroupoidAssociativity _ = property $ \(Apply2 (f :: s Integer Integer)) (Apply2 (g :: s Integer Integer)) (Apply2 (h :: s Integer Integer)) -> eq2 (f `o` (g `o` h)) ((f `o` g) `o` h)
 
 semigroupoidCommutativity :: forall proxy s.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Semigroupoid s, forall a b. (Eq a, Eq b) => Eq (s a b), forall a b. (Show a, Show b) => Show (s a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (s a b))
 #else
   (Semigroupoid s, Eq2 s, Show2 s, Arbitrary2 s)

--- a/src/Test/QuickCheck/Classes/Semigroupoid.hs
+++ b/src/Test/QuickCheck/Classes/Semigroupoid.hs
@@ -9,12 +9,10 @@
 
 module Test.QuickCheck.Classes.Semigroupoid
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 #if defined(VERSION_semigroupoids)
     semigroupoidLaws
   , commutativeSemigroupoidLaws
-#endif
 #endif
 #endif
   ) where
@@ -24,19 +22,17 @@ import Prelude hiding (id, (.))
 import Data.Semigroupoid (Semigroupoid(..))
 #endif
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 import Data.Functor.Classes (Eq2,Show2)
 #endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq2)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
+#if HAVE_BINARY_LAWS
 
 #if defined (VERSION_semigroupoids)
 -- | Tests the following 'Semigroupoid' properties:
@@ -92,8 +88,6 @@ semigroupoidCommutativity :: forall proxy s.
 #endif
   => proxy s -> Property
 semigroupoidCommutativity _ = property $ \(Apply2 (f :: s Integer Integer)) (Apply2 (g :: s Integer Integer)) -> eq2 (f `o` g) (g `o` f)
-
-#endif
 
 #endif
 

--- a/src/Test/QuickCheck/Classes/Semigroupoid.hs
+++ b/src/Test/QuickCheck/Classes/Semigroupoid.hs
@@ -9,32 +9,22 @@
 
 module Test.QuickCheck.Classes.Semigroupoid
   (
-#if HAVE_BINARY_LAWS
-#if defined(VERSION_semigroupoids)
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_BINARY_LAWS)
     semigroupoidLaws
   , commutativeSemigroupoidLaws
 #endif
-#endif
   ) where
 
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_BINARY_LAWS)
 import Prelude hiding (id, (.))
-#if defined(VERSION_semigroupoids)
 import Data.Semigroupoid (Semigroupoid(..))
-#endif
 import Test.QuickCheck hiding ((.&.))
-#if HAVE_BINARY_LAWS
 import Data.Functor.Classes (Eq2,Show2)
-#endif
 import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common
-#if HAVE_BINARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq2)
-#endif
 
-#if HAVE_BINARY_LAWS
-
-#if defined (VERSION_semigroupoids)
 -- | Tests the following 'Semigroupoid' properties:
 --
 -- [/Associativity/]
@@ -88,7 +78,5 @@ semigroupoidCommutativity :: forall proxy s.
 #endif
   => proxy s -> Property
 semigroupoidCommutativity _ = property $ \(Apply2 (f :: s Integer Integer)) (Apply2 (g :: s Integer Integer)) -> eq2 (f `o` g) (g `o` f)
-
-#endif
 
 #endif

--- a/src/Test/QuickCheck/Classes/Semiring.hs
+++ b/src/Test/QuickCheck/Classes/Semiring.hs
@@ -5,12 +5,12 @@
 
 module Test.QuickCheck.Classes.Semiring
   ( 
-#if defined(VERSION_semirings)
+#if HAVE_SEMIRINGS
     semiringLaws
 #endif
   ) where
 
-#if defined(VERSION_semirings)
+#if HAVE_SEMIRINGS
 import Data.Semiring
 import Prelude hiding (Num(..))
 #endif
@@ -21,7 +21,7 @@ import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Common (Laws(..), myForAllShrink)
 
-#if defined(VERSION_semirings)
+#if HAVE_SEMIRINGS
 -- | Tests the following properties:
 --
 -- [/Additive Commutativity/]

--- a/src/Test/QuickCheck/Classes/Traversable.hs
+++ b/src/Test/QuickCheck/Classes/Traversable.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -69,7 +69,7 @@ import Test.QuickCheck.Classes.Compat (eq1)
 -- * Identity: @t ('pure' x) ≡ 'pure' x@
 -- * Distributivity: @t (x '<*>' y) ≡ t x '<*>' t y@
 traversableLaws ::
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Traversable f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Traversable f, Eq1 f, Show1 f, Arbitrary1 f)
@@ -78,7 +78,7 @@ traversableLaws ::
 traversableLaws = traversableLawsInternal
 
 traversableLawsInternal :: forall proxy f.
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
   (Traversable f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))
 #else
   (Traversable f, Eq1 f, Show1 f, Arbitrary1 f)

--- a/src/Test/QuickCheck/Classes/Traversable.hs
+++ b/src/Test/QuickCheck/Classes/Traversable.hs
@@ -9,35 +9,29 @@
 
 module Test.QuickCheck.Classes.Traversable
   (
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
     traversableLaws
-#endif
 #endif
   ) where
 
 import Data.Foldable (foldMap)
 import Data.Traversable (Traversable,fmapDefault,foldMapDefault,sequenceA,traverse)
 import Test.QuickCheck hiding ((.&.))
-#if MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
 import Data.Functor.Classes (Eq1,Show1)
+#endif
 import Data.Functor.Compose
 import Data.Functor.Identity
-#endif
-#endif
 
 import qualified Data.Set as S
 
 import Test.QuickCheck.Classes.Common
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Test.QuickCheck.Classes.Compat (eq1)
 #endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 
 -- | Tests the following 'Traversable' properties:
 --
@@ -106,6 +100,3 @@ traversableLawsInternal _ = Laws "Traversable"
 
 
 #endif
-
-#endif
-

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -23,7 +23,7 @@ import qualified Data.Map as M
 import qualified Data.Map.Merge.Strict as MM
 #endif
 import Data.Traversable
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
 import Data.Functor.Apply (Apply((<.>)))
 #endif
 #if HAVE_UNARY_LAWS
@@ -47,7 +47,7 @@ import Test.QuickCheck.Classes
 
 main :: IO ()
 main = do
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
 #if MIN_VERSION_containers(0,5,9)
   quickCheck prop_map_apply_equals
 #endif
@@ -63,14 +63,10 @@ allPropsApplied =
   , ("Maybe",allHigherLaws (Proxy1 :: Proxy1 Maybe))
   , ("List",allHigherLaws (Proxy1 :: Proxy1 []))
 #endif
-#if HAVE_UNARY_LAWS
-#if MIN_VERSION_base(4,9,0)
-#if defined(VERSION_semigroupoids)
-#if MIN_VERSION_containers(0,5,9)
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_UNARY_LAWS)
+#if MIN_VERSION_base(4,9,0) && MIN_VERSION_containers(0,5,9)
   , ("Map", someHigherLaws (Proxy1 :: Proxy1 (Map Int)))
   , ("Pound", someHigherLaws (Proxy1 :: Proxy1 (Pound Int)))
-#endif
-#endif
 #endif
 #endif
 #if MIN_VERSION_base(4,7,0)
@@ -138,8 +134,7 @@ allHigherLaws p =
   ]
 #endif
 
-#if HAVE_UNARY_LAWS
-#if defined(VERSION_semigroupoids)
+#if defined(HAVE_SEMIGROUPOIDS) && defined(HAVE_UNARY_LAWS)
 someHigherLaws ::
   (Apply f,
 #if HAVE_QUANTIFIED_CONSTRAINTS
@@ -152,7 +147,6 @@ someHigherLaws ::
 someHigherLaws p =
   [ applyLaws p
   ]
-#endif
 #endif
 
 -- This type fails the laws for the strict functions
@@ -192,7 +186,7 @@ newtype Pound k v = Pound { getPound :: Map k v }
 #endif
   )
 
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
 #if MIN_VERSION_containers(0,5,9)
 instance Ord k => Apply (Pound k) where
   Pound m1 <.> Pound m2 = Pound $
@@ -205,7 +199,7 @@ instance Ord k => Apply (Pound k) where
 #endif
 #endif
 
-#if defined(VERSION_semigroupoids)
+#if HAVE_SEMIGROUPOIDS
 #if MIN_VERSION_containers(0,5,9)
 prop_map_apply_equals :: Map Int (Int -> Int)
                       -> Map Int Int

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DeriveFunctor #-}
 
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
@@ -26,7 +26,7 @@ import Data.Traversable
 #if defined(VERSION_semigroupoids)
 import Data.Functor.Apply (Apply((<.>)))
 #endif
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 import Data.Functor.Classes
 #endif
 import Data.Int
@@ -59,13 +59,11 @@ allPropsApplied =
   [ ("Int",allLaws (Proxy :: Proxy Int))
   , ("Int64",allLaws (Proxy :: Proxy Int64))
   , ("Word",allLaws (Proxy :: Proxy Word))
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
   , ("Maybe",allHigherLaws (Proxy1 :: Proxy1 Maybe))
   , ("List",allHigherLaws (Proxy1 :: Proxy1 []))
 #endif
-#endif
-#if MIN_VERSION_QuickCheck(2,10,0)
+#if HAVE_UNARY_LAWS
 #if MIN_VERSION_base(4,9,0)
 #if defined(VERSION_semigroupoids)
 #if MIN_VERSION_containers(0,5,9)
@@ -119,11 +117,10 @@ allLaws p =
 foldlMapM :: (Foldable t, Monoid b, Monad m) => (a -> m b) -> t a -> m b
 foldlMapM f = foldlM (\b a -> liftM (mappend b) (f a)) mempty
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 allHigherLaws ::
   (Traversable f, MonadZip f, MonadPlus f, Applicative f,
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
    forall a. Eq a => Eq (f a), forall a. Arbitrary a => Arbitrary (f a),
    forall a. Show a => Show (f a)
 #else
@@ -140,14 +137,12 @@ allHigherLaws p =
   , traversableLaws p
   ]
 #endif
-#endif
 
-#if MIN_VERSION_QuickCheck(2,10,0)
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
+#if HAVE_UNARY_LAWS
 #if defined(VERSION_semigroupoids)
 someHigherLaws ::
   (Apply f,
-#if MIN_VERSION_base(4,12,0)
+#if HAVE_QUANTIFIED_CONSTRAINTS
    forall a. Eq a => Eq (f a), forall a. Arbitrary a => Arbitrary (f a),
    forall a. Show a => Show (f a)
 #else
@@ -159,17 +154,19 @@ someHigherLaws p =
   ]
 #endif
 #endif
-#endif
 
 -- This type fails the laws for the strict functions
 -- in Foldable. It is used just to confirm that
 -- those property tests actually work.
 newtype Rouge a = Rouge [a]
-#if MIN_VERSION_QuickCheck(2,10,0) && (MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0))
-  deriving (Eq,Show,Arbitrary,Arbitrary1,Eq1,Show1)
-#else
-  deriving (Eq,Show,Arbitrary)
+  deriving
+  ( Eq, Show, Arbitrary
+#if HAVE_UNARY_LAWS
+  , Arbitrary1
+  , Eq1
+  , Show1
 #endif
+  )
 
 -- Note: when using base < 4.6, the Rouge type does
 -- not really test anything. 
@@ -182,11 +179,18 @@ instance Foldable Rouge where
 #endif
 
 newtype Pound k v = Pound { getPound :: Map k v }
-#if MIN_VERSION_QuickCheck(2,10,0) && MIN_VERSION_base(4,9,0) && MIN_VERSION_containers(0,5,9)
-  deriving (Eq,Functor,Show,Arbitrary,Arbitrary1,Eq1,Show1)
-#else
-  deriving (Eq,Functor,Show,Arbitrary)
+  deriving
+  ( Eq, Functor, Show, Arbitrary
+#if HAVE_UNARY_LAWS
+  , Arbitrary1
+  -- The following instances are only available for the variants
+  -- of the type classes in base, not for those in transformers.
+#if MIN_VERSION_base(4,9,0) && MIN_VERSION_containers(0,5,9)
+  , Eq1
+  , Show1
 #endif
+#endif
+  )
 
 #if defined(VERSION_semigroupoids)
 #if MIN_VERSION_containers(0,5,9)


### PR DESCRIPTION
This cleans up the pre-processor guards in the code base by using cabal flags and defined macros instead of the version checks. This PR slightly changes when some code is being built:

- Some internal functions, i.e. not exposed in the package, used solely for higher-kinded types are now skipped when not building any laws for higher-kinded types.
- The MonadFail and Generic1 laws are now also built for GHC 7.x.