### PR TITLE
Make advanced test suite unbuildable for old GHCs

### DIFF
--- a/quickcheck-classes.cabal
+++ b/quickcheck-classes.cabal
@@ -183,6 +183,8 @@ test-suite advanced
     , tasty-quickcheck
     , transformers
     , vector
+  if impl(ghc < 8.6)
+    buildable: False
 
 source-repository head
   type: git


### PR DESCRIPTION
This disables the advanced test suite component for GHC < 8.6 so that it's version bounds are not taken into consideration for the remaining components.