### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/quickcheck-classes-base/quickcheck-classes-base.cabal
+++ b/quickcheck-classes-base/quickcheck-classes-base.cabal
@@ -87,9 +87,10 @@ library
     , QuickCheck >= 2.7
     , transformers >= 0.3 && < 0.6
     , containers >= 0.4.2.1
-    , semigroups >= 0.17
     , tagged
     , fail
+  if impl(ghc < 8.0)
+    build-depends: semigroups >= 0.17
   if impl(ghc > 7.4) && impl(ghc < 7.6)
     build-depends: ghc-prim
   if impl(ghc > 8.5)

--- a/quickcheck-classes/quickcheck-classes.cabal
+++ b/quickcheck-classes/quickcheck-classes.cabal
@@ -101,10 +101,11 @@ library
     , primitive >= 0.6.4 && < 0.8
     , primitive-addr >= 0.1.0.2 && < 0.2
     , containers >= 0.4.2.1
-    , semigroups >= 0.17
     , tagged
     , fail
     , quickcheck-classes-base >=0.6 && <0.7
+  if impl(ghc < 8.0)
+    build-depends: semigroups >= 0.17
   if impl(ghc > 7.4) && impl(ghc < 7.6)
     build-depends: ghc-prim
   if impl(ghc > 8.5)


### PR DESCRIPTION
They are not needed on newer GHC.