### PR TITLE
Depend on fail only on GHC < 8

### DIFF
--- a/quickcheck-classes-base/quickcheck-classes-base.cabal
+++ b/quickcheck-classes-base/quickcheck-classes-base.cabal
@@ -88,9 +88,10 @@ library
     , transformers >= 0.3 && < 0.6
     , containers >= 0.4.2.1
     , tagged
-    , fail
   if impl(ghc < 8.0)
-    build-depends: semigroups >= 0.17
+    build-depends:
+        semigroups >= 0.17
+      , fail
   if impl(ghc > 7.4) && impl(ghc < 7.6)
     build-depends: ghc-prim
   if impl(ghc > 8.5)

--- a/quickcheck-classes/quickcheck-classes.cabal
+++ b/quickcheck-classes/quickcheck-classes.cabal
@@ -102,10 +102,11 @@ library
     , primitive-addr >= 0.1.0.2 && < 0.2
     , containers >= 0.4.2.1
     , tagged
-    , fail
     , quickcheck-classes-base >=0.6.1 && <0.7
   if impl(ghc < 8.0)
-    build-depends: semigroups >= 0.17
+    build-depends:
+        semigroups >= 0.17
+      , fail
   if impl(ghc > 7.4) && impl(ghc < 7.6)
     build-depends: ghc-prim
   if impl(ghc > 8.5)


### PR DESCRIPTION
It's not needed on new GHC