### PR TITLE
Fix Ix laws

### DIFF
--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Ix.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Ix.hs
@@ -31,19 +31,19 @@ ixLaws p = Laws "Ix"
   ]
 
 ixInRange :: forall a. (Show a, Ix a, Arbitrary a) => Proxy a -> Property
-ixInRange _ = property $ \(l :: a) (u :: a) (i :: a) -> (l <= u) ==> do
+ixInRange _ = property $ \(l :: a) (u :: a) (i :: a) ->
   inRange (l,u) i == elem i (range (l,u))
 
 ixRangeIndex :: forall a. (Show a, Ix a, Arbitrary a) => Proxy a -> Property
-ixRangeIndex _ = property $ \(l :: a) (u :: a) (i :: a) -> ((l <= u) && (i >= l && i <= u)) ==> do
-  range (l,u) !! index (l,u) i == i
+ixRangeIndex _ = property $ \(l :: a) (u :: a) (i :: a) ->
+  inRange (l,u) i ==> range (l,u) !! index (l,u) i == i
 
 ixMapIndexRange :: forall a. (Show a, Ix a, Arbitrary a) => Proxy a -> Property
-ixMapIndexRange _ = property $ \(l :: a) (u :: a) -> (l <= u) ==> do
+ixMapIndexRange _ = property $ \(l :: a) (u :: a) ->
   map (index (l,u)) (range (l,u)) == [0 .. rangeSize (l,u) - 1]
 
 ixRangeSize :: forall a. (Show a, Ix a, Arbitrary a) => Proxy a -> Property
-ixRangeSize _ = property $ \(l :: a) (u :: a) -> (l <= u) ==> do
+ixRangeSize _ = property $ \(l :: a) (u :: a) ->
   rangeSize (l,u) == length (range (l,u))
 
 


### PR DESCRIPTION
Changed the tests in `Tests.QuickCheck.Classes.Ix` to match
the laws in the documentation of `Data.Ix`

- In particular `ixRangeIndex` was incorrect:
  ```
  *> import Data.Ix
  *> x11 = (1,1) :: (Int,Int)
  *> x33 = (3,3) :: (Int,Int)
  *> x20 = (2,0) :: (Int,Int)
  *> x11 <= x33 && (x20 >= x11 && x20 <= x33)
  True
  (0.01 secs, 960,736 bytes)
  *> index (x11, x33) x20
  *** Exception: Error in array index
  *> inRange (x11, x33) x20
  False
  ```
- I'm confused by the `do`s in the code. Someone more experienced with QuickCheck than me should check if it is really ok to remove them. 

- I also removed the universal precondition that the lower bound is smaller than the upper bound, as it is not documented in `Data.Ix`. 

While `Ord` is a superclass of `Ix` the documented laws do not depend on `Ord`. Although the documentation introduces `Ix` as 

> mapping a contiguous subrange of values in a type onto integers.

In my mind this means that an instance of `Ord` orders the inhabitants of the type in a sequence. An instance of `Ix` drops some elements from that sequence (like `x20` in the example above) but retains the order of the remaining elements such that it is a subsequence.
Hence I think the following law captures the relation between `Ord` and `Ix`:
```
inRange (l,u) i && inRange (l,u) j ==> index (l,u) i < index j (l,u) == i < j
```
Though I have not added such a law in this commit.