### PR TITLE
More redundant dependencies

### DIFF
--- a/quickcheck-classes-base/quickcheck-classes-base.cabal
+++ b/quickcheck-classes-base/quickcheck-classes-base.cabal
@@ -81,7 +81,6 @@ library
     Test.QuickCheck.Classes.Traversable
   build-depends:
       base >= 4.5 && < 5
-    , base-orphans >= 0.1
     , QuickCheck >= 2.7
     , transformers >= 0.3 && < 0.6
     , containers >= 0.4.2.1

--- a/quickcheck-classes-base/quickcheck-classes-base.cabal
+++ b/quickcheck-classes-base/quickcheck-classes-base.cabal
@@ -85,7 +85,6 @@ library
     , QuickCheck >= 2.7
     , transformers >= 0.3 && < 0.6
     , containers >= 0.4.2.1
-    , tagged
   if impl(ghc < 8.6)
     build-depends: contravariant
   if impl(ghc < 8.2)
@@ -94,6 +93,8 @@ library
     build-depends:
         semigroups >= 0.17
       , fail
+  if impl(ghc < 7.8)
+    build-depends: tagged
   if impl(ghc > 7.4) && impl(ghc < 7.6)
     build-depends: ghc-prim
   if impl(ghc > 8.5)

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bifoldable.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bifoldable.hs
@@ -22,7 +22,6 @@ import Test.QuickCheck hiding ((.&.))
 import Data.Functor.Classes (Eq2,Show2)
 import Test.QuickCheck.Property (Property)
 import Data.Monoid
-import Data.Orphans ()
 import Test.QuickCheck.Classes.Internal
 #endif
 

--- a/quickcheck-classes/quickcheck-classes.cabal
+++ b/quickcheck-classes/quickcheck-classes.cabal
@@ -99,12 +99,13 @@ library
     , primitive >= 0.6.4 && < 0.8
     , primitive-addr >= 0.1.0.2 && < 0.2
     , containers >= 0.4.2.1
-    , tagged
     , quickcheck-classes-base >=0.6.1 && <0.7
   if impl(ghc < 8.0)
     build-depends:
         semigroups >= 0.17
       , fail
+  if impl(ghc < 7.8)
+    build-depends: tagged
   if impl(ghc > 7.4) && impl(ghc < 7.6)
     build-depends: ghc-prim
   if impl(ghc > 8.5)

--- a/quickcheck-classes/quickcheck-classes.cabal
+++ b/quickcheck-classes/quickcheck-classes.cabal
@@ -93,7 +93,6 @@ library
     Test.QuickCheck.Classes.Ring
   build-depends:
       base >= 4.5 && < 5
-    , base-orphans >= 0.1
     , QuickCheck >= 2.7
     , transformers >= 0.3 && < 0.6
     , primitive >= 0.6.4 && < 0.8


### PR DESCRIPTION
Not sure why `base-orphans` was used; I've been able to build with GHCs back to 7.4 without it. 

I'll appreciate a release with these changes, it would greatly simplify testing against bleeding edge GHCs.