### PR TITLE
Remove some unnecessary imports

### DIFF
--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Alternative.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Alternative.hs
@@ -20,7 +20,6 @@ import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Applicative.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Applicative.hs
@@ -20,7 +20,6 @@ import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Arrow.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Arrow.hs
@@ -23,7 +23,6 @@ import Test.QuickCheck hiding ((.&.))
 #if HAVE_BINARY_LAWS
 import Data.Functor.Classes (Eq2,Show2)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bifoldable.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bifoldable.hs
@@ -20,7 +20,6 @@ import Data.Bifoldable(Bifoldable(..))
 import Data.Bifunctor (Bifunctor(..))
 import Test.QuickCheck hiding ((.&.))
 import Data.Functor.Classes (Eq2,Show2)
-import Test.QuickCheck.Property (Property)
 import Data.Monoid
 import Test.QuickCheck.Classes.Internal
 #endif

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bifunctor.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bifunctor.hs
@@ -19,7 +19,6 @@ import Test.QuickCheck hiding ((.&.))
 #if HAVE_BINARY_LAWS
 import Data.Functor.Classes (Eq2,Show2)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 
@@ -31,10 +30,10 @@ import Test.QuickCheck.Classes.Internal
 --   @'bimap' 'id' 'id' ≡ 'id'@
 -- [/First Identity/]
 --   @'first' 'id' ≡ 'id'@
--- [/Second Identity/] 
+-- [/Second Identity/]
 --   @'second' 'id' ≡ 'id'@
 -- [/Bifunctor Composition/]
---   @'bimap' f g ≡ 'first' f '.' 'second' g@ 
+--   @'bimap' f g ≡ 'first' f '.' 'second' g@
 --
 -- /Note/: This property test is only available when this package is built with
 -- @base-4.9+@ or @transformers-0.5+@.
@@ -79,7 +78,7 @@ bifunctorSecondIdentity :: forall proxy f.
   => proxy f -> Property
 bifunctorSecondIdentity _ = property $ \(Apply2 (x :: f Integer Integer)) -> eq2 (second id x) x
 
-bifunctorComposition :: forall proxy f. 
+bifunctorComposition :: forall proxy f.
 #if HAVE_QUANTIFIED_CONSTRAINTS
   (Bifunctor f, forall a b. (Eq a, Eq b) => Eq (f a b), forall a b. (Show a, Show b) => Show (f a b), forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b))
 #else

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bitraversable.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bitraversable.hs
@@ -21,7 +21,6 @@ import Data.Functor.Compose (Compose(..))
 import Data.Functor.Identity (Identity(..))
 import Data.Functor.Classes (Eq2,Show2)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 
@@ -33,7 +32,7 @@ import Test.QuickCheck.Classes.Internal
 --   @'bitraverse' (t '.' f) (t '.' g) ≡ t '.' 'bitraverse' f g@ for every applicative transformation @t@
 -- [/Identity/]
 --   @'bitraverse' 'Identity' 'Identity' ≡ 'Identity'@
--- [/Composition/] 
+-- [/Composition/]
 --   @'Compose' '.' 'fmap' ('bitraverse' g1 g2) '.' 'bitraverse' f1 f2 ≡ 'bitraverse' ('Compose' '.' 'fmap' g1 g2 '.' f1) ('Compose' '.' 'fmap' g2 '.' f2)@
 --
 -- /Note/: This property test is only available when this package is built with

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bits.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Bits.hs
@@ -14,7 +14,6 @@ module Test.QuickCheck.Classes.Bits
 import Data.Bits
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import qualified Data.Set as S
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Category.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Category.hs
@@ -21,7 +21,6 @@ import Test.QuickCheck hiding ((.&.))
 #if HAVE_BINARY_LAWS
 import Data.Functor.Classes (Eq2,Show2)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Contravariant.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Contravariant.hs
@@ -22,7 +22,6 @@ import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Enum.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Enum.hs
@@ -9,7 +9,6 @@ module Test.QuickCheck.Classes.Enum
 
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..), myForAllShrink)
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Eq.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Eq.hs
@@ -9,7 +9,6 @@ module Test.QuickCheck.Classes.Eq
 
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 import Test.QuickCheck.Function
 
 import Test.QuickCheck.Classes.Internal (Laws(..))

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Foldable.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Foldable.hs
@@ -27,7 +27,6 @@ import Test.QuickCheck.Monadic (monadicIO)
 #if HAVE_UNARY_LAWS
 import Data.Functor.Classes (Eq1,Show1)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import qualified Data.Foldable as F
 import qualified Data.Semigroup as SG

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Functor.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Functor.hs
@@ -22,7 +22,6 @@ import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Generic.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Generic.hs
@@ -27,7 +27,6 @@ import Data.Functor.Classes
 #endif
 import Data.Proxy (Proxy(Proxy))
 import Test.QuickCheck
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..), Apply(..))
 
@@ -60,7 +59,7 @@ fromToInverse ::
   => proxy a
   -> proxy x
   -> Property
-fromToInverse _ _ = property $ \(r :: Rep a x) -> r == (from (to r :: a)) 
+fromToInverse _ _ = property $ \(r :: Rep a x) -> r == (from (to r :: a))
 
 #if HAVE_UNARY_LAWS
 -- | Tests the following properties:

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Integral.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Integral.hs
@@ -8,7 +8,6 @@ module Test.QuickCheck.Classes.Integral
 
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..), myForAllShrink)
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Ix.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Ix.hs
@@ -9,7 +9,6 @@ module Test.QuickCheck.Classes.Ix
 import Data.Ix (Ix(..))
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..))
 
@@ -20,7 +19,7 @@ import Test.QuickCheck.Classes.Internal (Laws(..))
 --   @'range' (l,u) '!!' 'index' (l,u) i '==' i@, when @'inRange' (l,u) i@
 --
 --   @'map' ('index' (l,u)) ('range' (l,u)) '==' [0 .. 'rangeSize' (l,u) - 1]@
---   
+--
 --   @'rangeSize' (l,u) '==' 'length' ('range' (l,u))@
 ixLaws :: (Ix a, Arbitrary a, Show a) => Proxy a -> Laws
 ixLaws p = Laws "Ix"

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Monad.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Monad.hs
@@ -21,7 +21,6 @@ import Control.Monad (ap)
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/MonadFail.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/MonadFail.hs
@@ -23,12 +23,11 @@ import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 
 -- | Tests the following 'MonadFail' properties:
--- 
+--
 -- [/Left Zero/]
 -- @'fail' s '>>=' f ≡ 'fail' s@
 monadFailLaws :: forall proxy f.
@@ -41,7 +40,7 @@ monadFailLaws :: forall proxy f.
 monadFailLaws p = Laws "Monad"
   [ ("Left Zero", monadFailLeftZero p)
   ]
- 
+
 monadFailLeftZero :: forall proxy f.
 #if HAVE_QUANTIFIED_CONSTRAINTS
   (MonadFail f, forall a. Eq a => Eq (f a), forall a. Show a => Show (f a), forall a. Arbitrary a => Arbitrary (f a))

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/MonadPlus.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/MonadPlus.hs
@@ -15,7 +15,6 @@ module Test.QuickCheck.Classes.MonadPlus
   ) where
 
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 import Test.QuickCheck.Classes.Internal
 import Control.Monad (MonadPlus(mzero,mplus))
 
@@ -33,7 +32,7 @@ import Data.Functor.Classes (Eq1,Show1)
 -- [/Right Identity/]
 --   @'mplus' x 'mzero' ≡ x@
 -- [/Associativity/]
---   @'mplus' a ('mplus' b c) ≡ 'mplus' ('mplus' a b) c)@ 
+--   @'mplus' a ('mplus' b c) ≡ 'mplus' ('mplus' a b) c)@
 -- [/Left Zero/]
 --   @'mzero' '>>=' f ≡ 'mzero'@
 -- [/Right Zero/]

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/MonadZip.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/MonadZip.hs
@@ -23,7 +23,6 @@ import Control.Monad (liftM)
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 #endif
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Monoid.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Monoid.hs
@@ -12,7 +12,6 @@ import Data.Semigroup
 import Data.Monoid
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..), SmallList(..), myForAllShrink)
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Num.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Num.hs
@@ -8,7 +8,6 @@ module Test.QuickCheck.Classes.Num
 
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..), myForAllShrink)
 

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Ord.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Ord.hs
@@ -8,14 +8,13 @@ module Test.QuickCheck.Classes.Ord
 
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..))
 
 -- | Tests the following properties:
 --
 -- [/Antisymmetry/]
---   @a ≤ b ∧ b ≤ a ⇒ a = b@ 
+--   @a ≤ b ∧ b ≤ a ⇒ a = b@
 -- [/Transitivity/]
 --   @a ≤ b ∧ b ≤ c ⇒ a ≤ c@
 -- [/Totality/]

--- a/quickcheck-classes-base/src/Test/QuickCheck/Classes/Semigroup.hs
+++ b/quickcheck-classes-base/src/Test/QuickCheck/Classes/Semigroup.hs
@@ -15,14 +15,11 @@ import Prelude hiding (foldr1)
 import Data.Semigroup (Semigroup(..))
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..), SmallList(..), myForAllShrink)
 
 import Data.Foldable (foldr1,toList)
 import Data.List.NonEmpty (NonEmpty((:|)))
-
-import qualified Data.List as L
 
 -- | Tests the following properties:
 --

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/Alt.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/Alt.hs
@@ -21,7 +21,6 @@ import qualified Data.Functor.Alt as Alt
 import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/Apply.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/Apply.hs
@@ -21,13 +21,12 @@ import qualified Data.Functor.Apply as FunctorApply
 import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 
 type ApplyProp proxy f =
 #if HAVE_QUANTIFIED_CONSTRAINTS
-  (FunctorApply.Apply f, forall x. Eq x => Eq (f x), forall x. Show x => Show (f x), forall x. Arbitrary x => Arbitrary (f x)) 
+  (FunctorApply.Apply f, forall x. Eq x => Eq (f x), forall x. Show x => Show (f x), forall x. Arbitrary x => Arbitrary (f x))
 #else
   (FunctorApply.Apply f, Eq1 f, Show1 f, Arbitrary1 f)
 #endif

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/Euclidean.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/Euclidean.hs
@@ -26,7 +26,6 @@ import Data.Euclidean
 import Data.Semiring (Semiring(..))
 
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..))
 

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/MVector.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/MVector.hs
@@ -26,7 +26,6 @@ import qualified Data.Vector.Generic.Mutable as MU (basicInitialize)
 import qualified Data.Vector.Unboxed.Mutable as MU
 
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..))
 

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/Plus.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/Plus.hs
@@ -26,7 +26,6 @@ import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Arbitrary (Arbitrary1(..))
 import Data.Functor.Classes (Eq1,Show1)
 import qualified Control.Applicative as Alternative
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/Prim.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/Prim.hs
@@ -32,7 +32,6 @@ import GHC.Exts (IsList(fromList,toList,fromListN),Item,
 import GHC.Ptr (Ptr(..))
 import System.IO.Unsafe
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import qualified Data.List as L
 import qualified Data.Primitive as P

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/Ring.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/Ring.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -Wall #-}
 
 module Test.QuickCheck.Classes.Ring
-  ( 
+  (
 #if HAVE_SEMIRINGS
     ringLaws
 #endif
@@ -17,7 +17,6 @@ import Prelude hiding (Num(..))
 
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..), myForAllShrink)
 

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/Semigroupoid.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/Semigroupoid.hs
@@ -20,7 +20,6 @@ import Prelude hiding (id, (.))
 import Data.Semigroupoid (Semigroupoid(..))
 import Test.QuickCheck hiding ((.&.))
 import Data.Functor.Classes (Eq2,Show2)
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal
 

--- a/quickcheck-classes/src/Test/QuickCheck/Classes/Semiring.hs
+++ b/quickcheck-classes/src/Test/QuickCheck/Classes/Semiring.hs
@@ -18,7 +18,6 @@ import Prelude (fromInteger)
 
 import Data.Proxy (Proxy)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property)
 
 import Test.QuickCheck.Classes.Internal (Laws(..), myForAllShrink)
 


### PR DESCRIPTION
Most modules explicitly `import Test.QuickCheck.Property (Property)`, eventhough `Property` is already exported by `Test.QuickCheck` (and has always been, afaict). Removing this reduces the amount of unused import warnings quite a bit. The only other changes are removing trailing whitespace (my editor does this automatically, but I don't see any reason to keep trailing whitespace anyway) and removing an unused `import qualified Data.List as L`. 