### PR TITLE
Remove note about flags only being for experts & update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # quickcheck-classes
 
-Quickcheck Properties for common typeclasses
+[QuickCheck](https://hackage.haskell.org/package/QuickCheck) properties for common typeclasses

--- a/quickcheck-classes/quickcheck-classes.cabal
+++ b/quickcheck-classes/quickcheck-classes.cabal
@@ -30,7 +30,7 @@ flag aeson
   description:
     You can disable the use of the @aeson@ package using @-f-aeson@.
     .
-    This may be useful for accelerating builds in sandboxes for expert users.
+    This may be useful for accelerating builds.
   default: True
   manual: True
 
@@ -38,7 +38,7 @@ flag semigroupoids
   description:
     You can disable the use of the @semigroupoids@ package using @-f-semigroupoids@.
     .
-    This may be useful for accelerating builds in sandboxes for expert users.
+    This may be useful for accelerating builds.
   default: True
   manual: True
 
@@ -46,7 +46,7 @@ flag semirings
   description:
     You can disable the use of the @semirings@ package using @-f-semirings@.
     .
-    This may be useful for accelerating builds in sandboxes for expert users.
+    This may be useful for accelerating builds.
   default: True
   manual: True
 
@@ -54,7 +54,7 @@ flag vector
   description:
     You can disable the use of the @vector@ package using @-f-vector@.
     .
-    This may be useful for accelerating builds in sandboxes for expert users.
+    This may be useful for accelerating builds.
   default: True
   manual: True
 


### PR DESCRIPTION
Disabling unneeded dependencies is useful regardless of being an expert, especially since `quickcheck-classes` is mainly used for testsuites, where it's unlikely to conflict with anything. I also removed the "in sandboxes" part, since sandboxes are the default, and added a link to [QuickCheck](https://hackage.haskell.org/package/QuickCheck).