### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -1,0 +1,26 @@
+name: Haskell CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10', '9.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - name: Build quickcheck-classes-base
+        run: cabal build quickcheck-classes-base
+      - name: Build quickcheck-classes
+        run: cabal build quickcheck-classes
+      - name: Test
+        run: |
+          cabal run quickcheck-classes:basic
+          cabal run quickcheck-classes:advanced


### PR DESCRIPTION
Closes #113.

It currently only tests GHC >= 8.6 (because that's what the advanced test suite requires), but I think that's better than not testing anything at all.