### PR TITLE
Remove unused `ghc-prim` dependency

### DIFF
--- a/quickcheck-classes-base/quickcheck-classes-base.cabal
+++ b/quickcheck-classes-base/quickcheck-classes-base.cabal
@@ -95,8 +95,6 @@ library
       , fail
   if impl(ghc < 7.8)
     build-depends: tagged
-  if impl(ghc > 7.4) && impl(ghc < 7.6)
-    build-depends: ghc-prim
   if impl(ghc > 8.5)
     cpp-options: -DHAVE_QUANTIFIED_CONSTRAINTS
   if flag(unary-laws)

--- a/quickcheck-classes/quickcheck-classes.cabal
+++ b/quickcheck-classes/quickcheck-classes.cabal
@@ -106,8 +106,6 @@ library
       , fail
   if impl(ghc < 7.8)
     build-depends: tagged
-  if impl(ghc > 7.4) && impl(ghc < 7.6)
-    build-depends: ghc-prim
   if impl(ghc > 8.5)
     cpp-options: -DHAVE_QUANTIFIED_CONSTRAINTS
   if flag(unary-laws)


### PR DESCRIPTION
I couldn't find any uses of modules from `ghc-prim`.